### PR TITLE
'[plugin-update] woocommerce 4.1.0 to 4.1.1'

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -27,14 +27,14 @@
 | [Polylang](https://wordpress.org/plugins/polylang/) | polylang | 2.7.2 | True | [https://polylang.pro](https://polylang.pro) |
 | [Two Factor Authentication](https://wordpress.org/plugins/two-factor-authentication/) | two-factor-authentication | 1.7.2 | True | [https://www.simbahosting.co.uk/s3/product/two-factor-authentication/](https://www.simbahosting.co.uk/s3/product/two-factor-authentication/) |
 | [VA Simple Basic Auth](https://wordpress.org/plugins/va-simple-basic-auth/) | va-simple-basic-auth | 1.1.0 | True | [https://github.com/VisuAlive/va-simple-basic-auth](https://github.com/VisuAlive/va-simple-basic-auth) |
-| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 4.1.1 | True | [https://woocommerce.com/](https://woocommerce.com/) |
+| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 4.1.0 | True | [https://woocommerce.com/](https://woocommerce.com/) |
 
 ## From Github Repository
 
 | Name | Version/Tag | Full only? | Repo |
 | --- | --- | --- | --- |
 | basic-auth | master | True | [https://github.com/wp-api/basic-auth](https://github.com/wp-api/basic-auth) |
-| wp-graphql | v0.9.0 |  | [https://github.com/wp-graphql/wp-graphql](https://github.com/wp-graphql/wp-graphql) |
+| wp-graphql | v0.8.4 |  | [https://github.com/wp-graphql/wp-graphql](https://github.com/wp-graphql/wp-graphql) |
 | wp-graphiql | v1.0.1 |  | [https://github.com/wp-graphql/wp-graphiql](https://github.com/wp-graphql/wp-graphiql) |
 | wp-graphql-acf | v0.3.3 |  | [https://github.com/wp-graphql/wp-graphql-acf](https://github.com/wp-graphql/wp-graphql-acf) |
 | wp-graphql-custom-post-type-ui | v1.1 |  | [https://github.com/wp-graphql/wp-graphql-custom-post-type-ui](https://github.com/wp-graphql/wp-graphql-custom-post-type-ui) |

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -27,7 +27,7 @@
 | [Polylang](https://wordpress.org/plugins/polylang/) | polylang | 2.7.2 | True | [https://polylang.pro](https://polylang.pro) |
 | [Two Factor Authentication](https://wordpress.org/plugins/two-factor-authentication/) | two-factor-authentication | 1.7.2 | True | [https://www.simbahosting.co.uk/s3/product/two-factor-authentication/](https://www.simbahosting.co.uk/s3/product/two-factor-authentication/) |
 | [VA Simple Basic Auth](https://wordpress.org/plugins/va-simple-basic-auth/) | va-simple-basic-auth | 1.1.0 | True | [https://github.com/VisuAlive/va-simple-basic-auth](https://github.com/VisuAlive/va-simple-basic-auth) |
-| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 4.1.0 | True | [https://woocommerce.com/](https://woocommerce.com/) |
+| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 4.1.1 | True | [https://woocommerce.com/](https://woocommerce.com/) |
 
 ## From Github Repository
 

--- a/build/full/composer.json
+++ b/build/full/composer.json
@@ -316,7 +316,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.1.zip"
         }
       }
     },

--- a/build/full/composer.json
+++ b/build/full/composer.json
@@ -316,7 +316,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.0.zip"
         }
       }
     },
@@ -340,7 +340,7 @@
         "name": "wp-graphql/wp-graphql",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/wp-graphql/wp-graphql/tarball/v0.9.0"
+          "url": "https://api.github.com/repos/wp-graphql/wp-graphql/tarball/v0.8.4"
         }
       }
     },

--- a/build/lite/composer.json
+++ b/build/lite/composer.json
@@ -316,7 +316,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.1.zip"
         }
       }
     },

--- a/build/lite/composer.json
+++ b/build/lite/composer.json
@@ -316,7 +316,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.4.1.0.zip"
         }
       }
     },
@@ -340,7 +340,7 @@
         "name": "wp-graphql/wp-graphql",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/wp-graphql/wp-graphql/tarball/v0.9.0"
+          "url": "https://api.github.com/repos/wp-graphql/wp-graphql/tarball/v0.8.4"
         }
       }
     },


### PR DESCRIPTION
- revert wp-graphql to v0.8.4
  - due to https://github.com/wp-graphql/wp-graphql/issues/1319