### PR TITLE
[plugin-add] Yoast Duplicate Post 4.4, and updates.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,4 +45,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.2.21
+   2.3.7

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -6,17 +6,18 @@
 | --- | --- | --- | --- | --- |
 | [ACF to REST API](https://wordpress.org/plugins/acf-to-rest-api/) | acf-to-rest-api | 3.3.2 |  | [http://github.com/airesvsg/acf-to-rest-api](http://github.com/airesvsg/acf-to-rest-api) |
 | [Advanced Custom Fields](https://wordpress.org/plugins/advanced-custom-fields/) | advanced-custom-fields | 5.11.4 |  | [https://www.advancedcustomfields.com](https://www.advancedcustomfields.com) |
-| [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/) | all-in-one-wp-migration | 7.53 |  | [https://servmask.com/](https://servmask.com/) |
-| [Atlas Content Modeler](https://wordpress.org/plugins/atlas-content-modeler/) | atlas-content-modeler | 0.13.0 |  | [https://developers.wpengine.com/](https://developers.wpengine.com/) |
+| [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/) | all-in-one-wp-migration | 7.55 |  | [https://servmask.com/](https://servmask.com/) |
+| [Atlas Content Modeler](https://wordpress.org/plugins/atlas-content-modeler/) | atlas-content-modeler | 0.14.0 |  | [https://developers.wpengine.com/](https://developers.wpengine.com/) |
 | [Classic Editor](https://wordpress.org/plugins/classic-editor/) | classic-editor | 1.6.2 |  | [https://wordpress.org/plugins/classic-editor/](https://wordpress.org/plugins/classic-editor/) |
 | [Admin Columns](https://wordpress.org/plugins/codepress-admin-columns/) | codepress-admin-columns | 4.4.5 |  | [https://www.admincolumns.com](https://www.admincolumns.com) |
 | [Custom Post Type UI](https://wordpress.org/plugins/custom-post-type-ui/) | custom-post-type-ui | 1.10.2 |  | [https://github.com/WebDevStudios/custom-post-type-ui/](https://github.com/WebDevStudios/custom-post-type-ui/) |
 | [Code Snippets](https://wordpress.org/plugins/code-snippets/) | code-snippets | 2.14.3 |  | [https://github.com/sheabunge/code-snippets](https://github.com/sheabunge/code-snippets) |
+| [Yoast Duplicate Post](https://wordpress.org/plugins/duplicate-post/) | duplicate-post | 4.4 |  | [https://yoast.com/wordpress/plugins/duplicate-post/](https://yoast.com/wordpress/plugins/duplicate-post/) |
 | [Enable Media Replace](https://wordpress.org/plugins/enable-media-replace/) | enable-media-replace | 3.6.3 |  | [https://wordpress.org/plugins/enable-media-replace/](https://wordpress.org/plugins/enable-media-replace/) |
 | [Export Media Library](https://wordpress.org/plugins/export-media-library/) | export-media-library | 3.0.1 |  | [https://github.com/massedge/wordpress-plugin-export-media-library](https://github.com/massedge/wordpress-plugin-export-media-library) |
-| [FaustWP](https://wordpress.org/plugins/faustwp/) | faustwp | 0.7.3 |  | [https://faustjs.org/](https://faustjs.org/) |
+| [FaustWP](https://wordpress.org/plugins/faustwp/) | faustwp | 0.7.4 |  | [https://faustjs.org/](https://faustjs.org/) |
 | [Intuitive Custom Post Order](https://wordpress.org/plugins/intuitive-custom-post-order/) | intuitive-custom-post-order | 3.1.3 |  | [http://hijiriworld.com/web/plugins/intuitive-custom-post-order/](http://hijiriworld.com/web/plugins/intuitive-custom-post-order/) |
-| [Redirection](https://wordpress.org/plugins/redirection/) | redirection | 5.2.2 |  | [https://redirection.me/](https://redirection.me/) |
+| [Redirection](https://wordpress.org/plugins/redirection/) | redirection | 5.2.3 |  | [https://redirection.me/](https://redirection.me/) |
 | [RSS Importer](https://wordpress.org/plugins/rss-importer/) | rss-importer | 0.2 |  | [http://wordpress.org/extend/plugins/rss-importer/](http://wordpress.org/extend/plugins/rss-importer/) |
 | [Search &amp; Replace](https://wordpress.org/plugins/search-and-replace/) | search-and-replace | 3.2.1 |  | [https://wordpress.org/plugins/search-and-replace/](https://wordpress.org/plugins/search-and-replace/) |
 | [TablePress](https://wordpress.org/plugins/tablepress/) | tablepress | 1.14 |  | [https://tablepress.org/](https://tablepress.org/) |
@@ -26,14 +27,14 @@
 | [WP REST Cache](https://wordpress.org/plugins/wp-rest-cache/) | wp-rest-cache | 2021.4.1 |  | [https://www.acato.nl](https://www.acato.nl) |
 | [Categories to Tags Converter](https://wordpress.org/plugins/wpcat2tag-importer/) | wpcat2tag-importer | 0.5 |  | [http://wordpress.org/extend/plugins/wpcat2tag-importer/](http://wordpress.org/extend/plugins/wpcat2tag-importer/) |
 | [JAMstack Deployments](https://wordpress.org/plugins/wp-jamstack-deployments/) | wp-jamstack-deployments | 1.1.1 |  | [https://github.com/crgeary/wp-jamstack-deployments](https://github.com/crgeary/wp-jamstack-deployments) |
-| [WPGatsby](https://wordpress.org/plugins/wp-gatsby/) | wp-gatsby | 2.2.1 |  | []() |
+| [WPGatsby](https://wordpress.org/plugins/wp-gatsby/) | wp-gatsby | 2.3.2 |  | []() |
 | [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) | wp-graphql | 1.6.11(pinned) |  | [https://github.com/wp-graphql/wp-graphql](https://github.com/wp-graphql/wp-graphql) |
 | [WP Search with Algolia](https://wordpress.org/plugins/wp-search-with-algolia/) | wp-search-with-algolia | 2.1.0 |  | [https://github.com/WebDevStudios/wp-search-with-algolia](https://github.com/WebDevStudios/wp-search-with-algolia) |
 | [Login LockDown](https://wordpress.org/plugins/login-lockdown/) | login-lockdown | v1.8.1 | True | [http://www.bad-neighborhood.com/](http://www.bad-neighborhood.com/) |
 | [Polylang](https://wordpress.org/plugins/polylang/) | polylang | 3.1.4 | True | [https://polylang.pro](https://polylang.pro) |
 | [Two Factor Authentication](https://wordpress.org/plugins/two-factor-authentication/) | two-factor-authentication | 1.14.3 | True | [https://www.simbahosting.co.uk/s3/product/two-factor-authentication/](https://www.simbahosting.co.uk/s3/product/two-factor-authentication/) |
 | [VA Simple Basic Auth](https://wordpress.org/plugins/va-simple-basic-auth/) | va-simple-basic-auth | 1.1.0 | True | [https://github.com/VisuAlive/va-simple-basic-auth](https://github.com/VisuAlive/va-simple-basic-auth) |
-| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 6.1.1 | True | [https://woocommerce.com/](https://woocommerce.com/) |
+| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 6.2.0 | True | [https://woocommerce.com/](https://woocommerce.com/) |
 
 ## From Github Repository
 

--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,7 @@ namespace :composer do
         body = JSON.load(URI.open(WP_PLUGIN_API % plugin['name']).read)
         if plugin['version_pin']
           download_link = body['versions'].find{|b| b[0] == plugin['version_pin']}.last
+          rakse unless download_link
           obj_repo[:package][:dist][:url] = download_link
           puts(plugin['name'], plugin['version_pin'] + '(pinned)' )
         else

--- a/build/full/composer.json
+++ b/build/full/composer.json
@@ -64,7 +64,7 @@
         "name": "wordpress/all-in-one-wp-migration",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.53.zip"
+          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.55.zip"
         }
       }
     },
@@ -76,7 +76,7 @@
         "name": "wordpress/atlas-content-modeler",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/atlas-content-modeler.0.13.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/atlas-content-modeler.0.14.0.zip"
         }
       }
     },
@@ -133,6 +133,18 @@
       "package": {
         "version": "dev-master",
         "type": "wordpress-plugin",
+        "name": "wordpress/duplicate-post",
+        "dist": {
+          "type": "zip",
+          "url": "https://downloads.wordpress.org/plugin/duplicate-post.4.4.zip"
+        }
+      }
+    },
+    {
+      "type": "package",
+      "package": {
+        "version": "dev-master",
+        "type": "wordpress-plugin",
         "name": "wordpress/enable-media-replace",
         "dist": {
           "type": "zip",
@@ -160,7 +172,7 @@
         "name": "wordpress/faustwp",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/faustwp.0.7.3.zip"
+          "url": "https://downloads.wordpress.org/plugin/faustwp.0.7.4.zip"
         }
       }
     },
@@ -304,7 +316,7 @@
         "name": "wordpress/wp-gatsby",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/wp-gatsby.2.2.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/wp-gatsby.2.3.2.zip"
         }
       }
     },
@@ -388,7 +400,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.6.1.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.6.2.0.zip"
         }
       }
     },
@@ -512,6 +524,7 @@
     "wordpress/codepress-admin-columns": "dev-master",
     "wordpress/custom-post-type-ui": "dev-master",
     "wordpress/code-snippets": "dev-master",
+    "wordpress/duplicate-post": "dev-master",
     "wordpress/enable-media-replace": "dev-master",
     "wordpress/export-media-library": "dev-master",
     "wordpress/faustwp": "dev-master",

--- a/build/lite/composer.json
+++ b/build/lite/composer.json
@@ -64,7 +64,7 @@
         "name": "wordpress/all-in-one-wp-migration",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.53.zip"
+          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.55.zip"
         }
       }
     },
@@ -76,7 +76,7 @@
         "name": "wordpress/atlas-content-modeler",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/atlas-content-modeler.0.13.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/atlas-content-modeler.0.14.0.zip"
         }
       }
     },
@@ -133,6 +133,18 @@
       "package": {
         "version": "dev-master",
         "type": "wordpress-plugin",
+        "name": "wordpress/duplicate-post",
+        "dist": {
+          "type": "zip",
+          "url": "https://downloads.wordpress.org/plugin/duplicate-post.4.4.zip"
+        }
+      }
+    },
+    {
+      "type": "package",
+      "package": {
+        "version": "dev-master",
+        "type": "wordpress-plugin",
         "name": "wordpress/enable-media-replace",
         "dist": {
           "type": "zip",
@@ -160,7 +172,7 @@
         "name": "wordpress/faustwp",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/faustwp.0.7.3.zip"
+          "url": "https://downloads.wordpress.org/plugin/faustwp.0.7.4.zip"
         }
       }
     },
@@ -304,7 +316,7 @@
         "name": "wordpress/wp-gatsby",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/wp-gatsby.2.2.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/wp-gatsby.2.3.2.zip"
         }
       }
     },
@@ -388,7 +400,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.6.1.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.6.2.0.zip"
         }
       }
     },
@@ -512,6 +524,7 @@
     "wordpress/codepress-admin-columns": "dev-master",
     "wordpress/custom-post-type-ui": "dev-master",
     "wordpress/code-snippets": "dev-master",
+    "wordpress/duplicate-post": "dev-master",
     "wordpress/enable-media-replace": "dev-master",
     "wordpress/export-media-library": "dev-master",
     "wordpress/faustwp": "dev-master",

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,6 +2,7 @@
 version: '3.8'
 services:
   sut:
+    platform: linux/amd64
     build:
       context: ./test
     depends_on:
@@ -10,6 +11,7 @@ services:
       - plugindata:/srv/plugins
       - ./test/results:/srv/results
   plugins:
+    platform: linux/amd64
     image: getshifter/headless-plugins:stable
     volumes:
       - plugindata:/srv/plugins

--- a/plugins.yml
+++ b/plugins.yml
@@ -8,6 +8,7 @@ wordpress:
   - name: codepress-admin-columns
   - name: custom-post-type-ui
   - name: code-snippets
+  - name: duplicate-post
   - name: enable-media-replace
   - name: export-media-library
   - name: faustwp


### PR DESCRIPTION
- [plugin-add] Yoast Duplicate Post 4.4
- [plugin-update] All-in-One WP Migration 7.55, Atlas Content Modeler 0.14.0, FaustWP 0.7.4, Redirection 5.2.3, WPGatsby 2.3.2, WooCommerce 6.2.0