### PR TITLE
update plugins for wp 6.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,4 +45,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.4.7
+   2.4.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,4 +45,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.4.10
+   2.4.12

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -5,26 +5,26 @@
 | Name | Slug | Version | Full only? | Homepage |
 | --- | --- | --- | --- | --- |
 | [ACF to REST API](https://wordpress.org/plugins/acf-to-rest-api/) | acf-to-rest-api | 3.3.3 |  | [http://github.com/airesvsg/acf-to-rest-api](http://github.com/airesvsg/acf-to-rest-api) |
-| [Advanced Custom Fields](https://wordpress.org/plugins/advanced-custom-fields/) | advanced-custom-fields | 6.0.7 |  | [https://www.advancedcustomfields.com](https://www.advancedcustomfields.com) |
-| [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/) | all-in-one-wp-migration | 7.71 |  | [https://servmask.com/](https://servmask.com/) |
+| [Advanced Custom Fields (ACF)](https://wordpress.org/plugins/advanced-custom-fields/) | advanced-custom-fields | 6.1.3 |  | [https://www.advancedcustomfields.com](https://www.advancedcustomfields.com) |
+| [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/) | all-in-one-wp-migration | 7.73 |  | [https://servmask.com/](https://servmask.com/) |
 | [Atlas Content Modeler](https://wordpress.org/plugins/atlas-content-modeler/) | atlas-content-modeler | 0.24.0 |  | [https://developers.wpengine.com/](https://developers.wpengine.com/) |
-| [Classic Editor](https://wordpress.org/plugins/classic-editor/) | classic-editor | 1.6.2 |  | [https://wordpress.org/plugins/classic-editor/](https://wordpress.org/plugins/classic-editor/) |
-| [Admin Columns](https://wordpress.org/plugins/codepress-admin-columns/) | codepress-admin-columns | 4.5.5 |  | [https://www.admincolumns.com](https://www.admincolumns.com) |
-| [Custom Post Type UI](https://wordpress.org/plugins/custom-post-type-ui/) | custom-post-type-ui | 1.13.4 |  | [https://github.com/WebDevStudios/custom-post-type-ui/](https://github.com/WebDevStudios/custom-post-type-ui/) |
-| [Code Snippets](https://wordpress.org/plugins/code-snippets/) | code-snippets | 3.2.2 |  | [https://codesnippets.pro](https://codesnippets.pro) |
+| [Classic Editor](https://wordpress.org/plugins/classic-editor/) | classic-editor | 1.6.3 |  | [https://wordpress.org/plugins/classic-editor/](https://wordpress.org/plugins/classic-editor/) |
+| [Admin Columns](https://wordpress.org/plugins/codepress-admin-columns/) | codepress-admin-columns | 4.6.1 |  | [https://www.admincolumns.com](https://www.admincolumns.com) |
+| [Custom Post Type UI](https://wordpress.org/plugins/custom-post-type-ui/) | custom-post-type-ui | 1.13.5 |  | [https://github.com/WebDevStudios/custom-post-type-ui/](https://github.com/WebDevStudios/custom-post-type-ui/) |
+| [Code Snippets](https://wordpress.org/plugins/code-snippets/) | code-snippets | 3.3.0 |  | [https://codesnippets.pro](https://codesnippets.pro) |
 | [Yoast Duplicate Post](https://wordpress.org/plugins/duplicate-post/) | duplicate-post | 4.5 |  | [https://yoast.com/wordpress/plugins/duplicate-post/](https://yoast.com/wordpress/plugins/duplicate-post/) |
-| [Enable Media Replace](https://wordpress.org/plugins/enable-media-replace/) | enable-media-replace | 4.0.3 |  | [https://wordpress.org/plugins/enable-media-replace/](https://wordpress.org/plugins/enable-media-replace/) |
-| [Export Media Library](https://wordpress.org/plugins/export-media-library/) | export-media-library | 4.0.0 |  | [https://github.com/massedge/wordpress-plugin-export-media-library](https://github.com/massedge/wordpress-plugin-export-media-library) |
-| [Faust](https://wordpress.org/plugins/faustwp/) | faustwp | 0.8.1 |  | [https://faustjs.org/](https://faustjs.org/) |
+| [Enable Media Replace](https://wordpress.org/plugins/enable-media-replace/) | enable-media-replace | 4.1.0 |  | [https://wordpress.org/plugins/enable-media-replace/](https://wordpress.org/plugins/enable-media-replace/) |
+| [Export Media Library](https://wordpress.org/plugins/export-media-library/) | export-media-library | 4.0.2 |  | [https://github.com/massedge/wordpress-plugin-export-media-library](https://github.com/massedge/wordpress-plugin-export-media-library) |
+| [Faust](https://wordpress.org/plugins/faustwp/) | faustwp | 0.8.4 |  | [https://faustjs.org/](https://faustjs.org/) |
 | [Intuitive Custom Post Order](https://wordpress.org/plugins/intuitive-custom-post-order/) | intuitive-custom-post-order | 3.1.4.1 |  | [http://hijiriworld.com/web/plugins/intuitive-custom-post-order/](http://hijiriworld.com/web/plugins/intuitive-custom-post-order/) |
 | [Post Type Switcher](https://wordpress.org/plugins/post-type-switcher/) | post-type-switcher | 3.2.1 |  | [https://wordpress.org/plugins/post-type-switcher](https://wordpress.org/plugins/post-type-switcher) |
-| [Redirection](https://wordpress.org/plugins/redirection/) | redirection | 5.3.9 |  | [https://redirection.me/](https://redirection.me/) |
+| [Redirection](https://wordpress.org/plugins/redirection/) | redirection | 5.3.10 |  | [https://redirection.me/](https://redirection.me/) |
 | [RSS Importer](https://wordpress.org/plugins/rss-importer/) | rss-importer | 0.3 |  | [http://wordpress.org/extend/plugins/rss-importer/](http://wordpress.org/extend/plugins/rss-importer/) |
-| [Safe SVG](https://wordpress.org/plugins/safe-svg/) | safe-svg | 2.0.3 |  | [https://wordpress.org/plugins/safe-svg/](https://wordpress.org/plugins/safe-svg/) |
+| [Safe SVG](https://wordpress.org/plugins/safe-svg/) | safe-svg | 2.1.1 |  | [https://wordpress.org/plugins/safe-svg/](https://wordpress.org/plugins/safe-svg/) |
 | [Search &amp; Replace](https://wordpress.org/plugins/search-and-replace/) | search-and-replace | 3.2.1 |  | [https://wordpress.org/plugins/search-and-replace/](https://wordpress.org/plugins/search-and-replace/) |
-| [TablePress](https://wordpress.org/plugins/tablepress/) | tablepress | 2.0.4 |  | [https://tablepress.org/](https://tablepress.org/) |
-| [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) | the-events-calendar | 6.0.10 |  | []() |
-| [User Role Editor](https://wordpress.org/plugins/user-role-editor/) | user-role-editor | 4.63.2 |  | [https://www.role-editor.com](https://www.role-editor.com) |
+| [TablePress](https://wordpress.org/plugins/tablepress/) | tablepress | 2.1 |  | [https://tablepress.org/](https://tablepress.org/) |
+| [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) | the-events-calendar | 6.0.11 |  | []() |
+| [User Role Editor](https://wordpress.org/plugins/user-role-editor/) | user-role-editor | 4.63.3 |  | [https://www.role-editor.com](https://www.role-editor.com) |
 | [User Switching](https://wordpress.org/plugins/user-switching/) | user-switching | 1.7.0 |  | [https://wordpress.org/plugins/user-switching/](https://wordpress.org/plugins/user-switching/) |
 | [WordPress Importer](https://wordpress.org/plugins/wordpress-importer/) | wordpress-importer | 0.8 |  | [https://wordpress.org/plugins/wordpress-importer/](https://wordpress.org/plugins/wordpress-importer/) |
 | [WP REST API Controller](https://wordpress.org/plugins/wp-rest-api-controller/) | wp-rest-api-controller | 2.1.2 |  | []() |
@@ -32,13 +32,13 @@
 | [Categories to Tags Converter](https://wordpress.org/plugins/wpcat2tag-importer/) | wpcat2tag-importer | 0.6 |  | [http://wordpress.org/extend/plugins/wpcat2tag-importer/](http://wordpress.org/extend/plugins/wpcat2tag-importer/) |
 | [JAMstack Deployments](https://wordpress.org/plugins/wp-jamstack-deployments/) | wp-jamstack-deployments | 1.1.1 |  | [https://github.com/crgeary/wp-jamstack-deployments](https://github.com/crgeary/wp-jamstack-deployments) |
 | [WPGatsby](https://wordpress.org/plugins/wp-gatsby/) | wp-gatsby | 2.3.3 |  | []() |
-| [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) | wp-graphql | 1.6.11(pinned) |  | [https://github.com/wp-graphql/wp-graphql](https://github.com/wp-graphql/wp-graphql) |
-| [WP Search with Algolia](https://wordpress.org/plugins/wp-search-with-algolia/) | wp-search-with-algolia | 2.4.0 |  | [https://github.com/WebDevStudios/wp-search-with-algolia](https://github.com/WebDevStudios/wp-search-with-algolia) |
+| [WPGraphQL](https://wordpress.org/plugins/wp-graphql/) | wp-graphql | 1.14.0 |  | [https://github.com/wp-graphql/wp-graphql](https://github.com/wp-graphql/wp-graphql) |
+| [WP Search with Algolia](https://wordpress.org/plugins/wp-search-with-algolia/) | wp-search-with-algolia | 2.5.0 |  | [https://github.com/WebDevStudios/wp-search-with-algolia](https://github.com/WebDevStudios/wp-search-with-algolia) |
 | [Login LockDown &#8211; Protect Login Form](https://wordpress.org/plugins/login-lockdown/) | login-lockdown | 1.83 | True | [https://wploginlockdown.com/](https://wploginlockdown.com/) |
-| [Polylang](https://wordpress.org/plugins/polylang/) | polylang | 3.3.1 | True | [https://polylang.pro](https://polylang.pro) |
-| [Two Factor Authentication](https://wordpress.org/plugins/two-factor-authentication/) | two-factor-authentication | 1.14.11 | True | [https://www.simbahosting.co.uk/s3/product/two-factor-authentication/](https://www.simbahosting.co.uk/s3/product/two-factor-authentication/) |
+| [Polylang](https://wordpress.org/plugins/polylang/) | polylang | 3.3.2 | True | [https://polylang.pro](https://polylang.pro) |
+| [Two Factor Authentication](https://wordpress.org/plugins/two-factor-authentication/) | two-factor-authentication | 1.14.14 | True | [https://www.simbahosting.co.uk/s3/product/two-factor-authentication/](https://www.simbahosting.co.uk/s3/product/two-factor-authentication/) |
 | [VA Simple Basic Auth](https://wordpress.org/plugins/va-simple-basic-auth/) | va-simple-basic-auth | 1.1.0 | True | [https://github.com/VisuAlive/va-simple-basic-auth](https://github.com/VisuAlive/va-simple-basic-auth) |
-| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 7.4.1 | True | [https://woocommerce.com/](https://woocommerce.com/) |
+| [WooCommerce](https://wordpress.org/plugins/woocommerce/) | woocommerce | 7.5.1 | True | [https://woocommerce.com/](https://woocommerce.com/) |
 
 ## From Github Repository
 
@@ -47,10 +47,10 @@
 | basic-auth | master | True | [https://github.com/wp-api/basic-auth](https://github.com/wp-api/basic-auth) |
 | wp-graphql-acf | v0.6.1 |  | [https://github.com/wp-graphql/wp-graphql-acf](https://github.com/wp-graphql/wp-graphql-acf) |
 | wp-graphql-custom-post-type-ui | v1.2.0 |  | [https://github.com/wp-graphql/wp-graphql-custom-post-type-ui](https://github.com/wp-graphql/wp-graphql-custom-post-type-ui) |
-| wp-graphql-jwt-authentication | v0.6.0 | True | [https://github.com/wp-graphql/wp-graphql-jwt-authentication](https://github.com/wp-graphql/wp-graphql-jwt-authentication) |
-| wp-graphql-woocommerce | v0.12.1 | True | [https://github.com/wp-graphql/wp-graphql-woocommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) |
+| wp-graphql-jwt-authentication | v0.7.0 | True | [https://github.com/wp-graphql/wp-graphql-jwt-authentication](https://github.com/wp-graphql/wp-graphql-jwt-authentication) |
+| wp-graphql-woocommerce | v0.12.3 | True | [https://github.com/wp-graphql/wp-graphql-woocommerce](https://github.com/wp-graphql/wp-graphql-woocommerce) |
 | wp-graphql-polylang | v0.6.0 | True | [https://github.com/valu-digital/wp-graphql-polylang](https://github.com/valu-digital/wp-graphql-polylang) |
-| wp-graphql-gutenberg | v0.3.11(pinned) |  | [https://github.com/pristas-peter/wp-graphql-gutenberg](https://github.com/pristas-peter/wp-graphql-gutenberg) |
+| wp-graphql-gutenberg | v0.4.1 |  | [https://github.com/pristas-peter/wp-graphql-gutenberg](https://github.com/pristas-peter/wp-graphql-gutenberg) |
 | wp-graphql-gutenberg-acf | v0.3.0 |  | [https://github.com/pristas-peter/wp-graphql-gutenberg-acf](https://github.com/pristas-peter/wp-graphql-gutenberg-acf) |
 
 ## Others

--- a/build/full/composer.json
+++ b/build/full/composer.json
@@ -52,7 +52,7 @@
         "name": "wordpress/advanced-custom-fields",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/advanced-custom-fields.6.0.7.zip"
+          "url": "https://downloads.wordpress.org/plugin/advanced-custom-fields.6.1.3.zip"
         }
       }
     },
@@ -64,7 +64,7 @@
         "name": "wordpress/all-in-one-wp-migration",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.71.zip"
+          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.73.zip"
         }
       }
     },
@@ -88,7 +88,7 @@
         "name": "wordpress/classic-editor",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/classic-editor.1.6.2.zip"
+          "url": "https://downloads.wordpress.org/plugin/classic-editor.1.6.3.zip"
         }
       }
     },
@@ -100,7 +100,7 @@
         "name": "wordpress/codepress-admin-columns",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/codepress-admin-columns.4.5.5.zip"
+          "url": "https://downloads.wordpress.org/plugin/codepress-admin-columns.4.6.1.zip"
         }
       }
     },
@@ -112,7 +112,7 @@
         "name": "wordpress/custom-post-type-ui",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/custom-post-type-ui.1.13.4.zip"
+          "url": "https://downloads.wordpress.org/plugin/custom-post-type-ui.1.13.5.zip"
         }
       }
     },
@@ -124,7 +124,7 @@
         "name": "wordpress/code-snippets",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/code-snippets.3.2.2.zip"
+          "url": "https://downloads.wordpress.org/plugin/code-snippets.3.3.0.zip"
         }
       }
     },
@@ -148,7 +148,7 @@
         "name": "wordpress/enable-media-replace",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/enable-media-replace.4.0.3.zip"
+          "url": "https://downloads.wordpress.org/plugin/enable-media-replace.4.1.0.zip"
         }
       }
     },
@@ -160,7 +160,7 @@
         "name": "wordpress/export-media-library",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/export-media-library.4.0.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/export-media-library.4.0.2.zip"
         }
       }
     },
@@ -172,7 +172,7 @@
         "name": "wordpress/faustwp",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/faustwp.0.8.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/faustwp.0.8.4.zip"
         }
       }
     },
@@ -208,7 +208,7 @@
         "name": "wordpress/redirection",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/redirection.5.3.9.zip"
+          "url": "https://downloads.wordpress.org/plugin/redirection.5.3.10.zip"
         }
       }
     },
@@ -232,7 +232,7 @@
         "name": "wordpress/safe-svg",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/safe-svg.2.0.3.zip"
+          "url": "https://downloads.wordpress.org/plugin/safe-svg.2.1.1.zip"
         }
       }
     },
@@ -256,7 +256,7 @@
         "name": "wordpress/tablepress",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/tablepress.2.0.4.zip"
+          "url": "https://downloads.wordpress.org/plugin/tablepress.2.1.zip"
         }
       }
     },
@@ -268,7 +268,7 @@
         "name": "wordpress/the-events-calendar",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/the-events-calendar.6.0.10.zip"
+          "url": "https://downloads.wordpress.org/plugin/the-events-calendar.6.0.11.zip"
         }
       }
     },
@@ -280,7 +280,7 @@
         "name": "wordpress/user-role-editor",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/user-role-editor.4.63.2.zip"
+          "url": "https://downloads.wordpress.org/plugin/user-role-editor.4.63.3.zip"
         }
       }
     },
@@ -376,7 +376,7 @@
         "name": "wordpress/wp-graphql",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/wp-graphql.1.6.11.zip"
+          "url": "https://downloads.wordpress.org/plugin/wp-graphql.1.14.0.zip"
         }
       }
     },
@@ -388,7 +388,7 @@
         "name": "wordpress/wp-search-with-algolia",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/wp-search-with-algolia.2.4.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/wp-search-with-algolia.2.5.0.zip"
         }
       }
     },
@@ -412,7 +412,7 @@
         "name": "wordpress/polylang",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/polylang.3.3.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/polylang.3.3.2.zip"
         }
       }
     },
@@ -424,7 +424,7 @@
         "name": "wordpress/two-factor-authentication",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/two-factor-authentication.1.14.11.zip"
+          "url": "https://downloads.wordpress.org/plugin/two-factor-authentication.1.14.14.zip"
         }
       }
     },
@@ -448,7 +448,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.7.4.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.7.5.1.zip"
         }
       }
     },
@@ -496,7 +496,7 @@
         "name": "wp-graphql/wp-graphql-jwt-authentication",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-jwt-authentication/tarball/v0.6.0"
+          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-jwt-authentication/tarball/v0.7.0"
         }
       }
     },
@@ -508,7 +508,7 @@
         "name": "wp-graphql/wp-graphql-woocommerce",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-woocommerce/tarball/v0.12.1"
+          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-woocommerce/tarball/v0.12.3"
         }
       }
     },
@@ -532,7 +532,7 @@
         "name": "pristas-peter/wp-graphql-gutenberg",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/pristas-peter/wp-graphql-gutenberg/tarball/v0.3.11"
+          "url": "https://api.github.com/repos/pristas-peter/wp-graphql-gutenberg/tarball/v0.4.1"
         }
       }
     },

--- a/build/lite/composer.json
+++ b/build/lite/composer.json
@@ -52,7 +52,7 @@
         "name": "wordpress/advanced-custom-fields",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/advanced-custom-fields.6.0.7.zip"
+          "url": "https://downloads.wordpress.org/plugin/advanced-custom-fields.6.1.3.zip"
         }
       }
     },
@@ -64,7 +64,7 @@
         "name": "wordpress/all-in-one-wp-migration",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.71.zip"
+          "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.73.zip"
         }
       }
     },
@@ -88,7 +88,7 @@
         "name": "wordpress/classic-editor",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/classic-editor.1.6.2.zip"
+          "url": "https://downloads.wordpress.org/plugin/classic-editor.1.6.3.zip"
         }
       }
     },
@@ -100,7 +100,7 @@
         "name": "wordpress/codepress-admin-columns",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/codepress-admin-columns.4.5.5.zip"
+          "url": "https://downloads.wordpress.org/plugin/codepress-admin-columns.4.6.1.zip"
         }
       }
     },
@@ -112,7 +112,7 @@
         "name": "wordpress/custom-post-type-ui",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/custom-post-type-ui.1.13.4.zip"
+          "url": "https://downloads.wordpress.org/plugin/custom-post-type-ui.1.13.5.zip"
         }
       }
     },
@@ -124,7 +124,7 @@
         "name": "wordpress/code-snippets",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/code-snippets.3.2.2.zip"
+          "url": "https://downloads.wordpress.org/plugin/code-snippets.3.3.0.zip"
         }
       }
     },
@@ -148,7 +148,7 @@
         "name": "wordpress/enable-media-replace",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/enable-media-replace.4.0.3.zip"
+          "url": "https://downloads.wordpress.org/plugin/enable-media-replace.4.1.0.zip"
         }
       }
     },
@@ -160,7 +160,7 @@
         "name": "wordpress/export-media-library",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/export-media-library.4.0.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/export-media-library.4.0.2.zip"
         }
       }
     },
@@ -172,7 +172,7 @@
         "name": "wordpress/faustwp",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/faustwp.0.8.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/faustwp.0.8.4.zip"
         }
       }
     },
@@ -208,7 +208,7 @@
         "name": "wordpress/redirection",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/redirection.5.3.9.zip"
+          "url": "https://downloads.wordpress.org/plugin/redirection.5.3.10.zip"
         }
       }
     },
@@ -232,7 +232,7 @@
         "name": "wordpress/safe-svg",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/safe-svg.2.0.3.zip"
+          "url": "https://downloads.wordpress.org/plugin/safe-svg.2.1.1.zip"
         }
       }
     },
@@ -256,7 +256,7 @@
         "name": "wordpress/tablepress",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/tablepress.2.0.4.zip"
+          "url": "https://downloads.wordpress.org/plugin/tablepress.2.1.zip"
         }
       }
     },
@@ -268,7 +268,7 @@
         "name": "wordpress/the-events-calendar",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/the-events-calendar.6.0.10.zip"
+          "url": "https://downloads.wordpress.org/plugin/the-events-calendar.6.0.11.zip"
         }
       }
     },
@@ -280,7 +280,7 @@
         "name": "wordpress/user-role-editor",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/user-role-editor.4.63.2.zip"
+          "url": "https://downloads.wordpress.org/plugin/user-role-editor.4.63.3.zip"
         }
       }
     },
@@ -376,7 +376,7 @@
         "name": "wordpress/wp-graphql",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/wp-graphql.1.6.11.zip"
+          "url": "https://downloads.wordpress.org/plugin/wp-graphql.1.14.0.zip"
         }
       }
     },
@@ -388,7 +388,7 @@
         "name": "wordpress/wp-search-with-algolia",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/wp-search-with-algolia.2.4.0.zip"
+          "url": "https://downloads.wordpress.org/plugin/wp-search-with-algolia.2.5.0.zip"
         }
       }
     },
@@ -412,7 +412,7 @@
         "name": "wordpress/polylang",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/polylang.3.3.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/polylang.3.3.2.zip"
         }
       }
     },
@@ -424,7 +424,7 @@
         "name": "wordpress/two-factor-authentication",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/two-factor-authentication.1.14.11.zip"
+          "url": "https://downloads.wordpress.org/plugin/two-factor-authentication.1.14.14.zip"
         }
       }
     },
@@ -448,7 +448,7 @@
         "name": "wordpress/woocommerce",
         "dist": {
           "type": "zip",
-          "url": "https://downloads.wordpress.org/plugin/woocommerce.7.4.1.zip"
+          "url": "https://downloads.wordpress.org/plugin/woocommerce.7.5.1.zip"
         }
       }
     },
@@ -496,7 +496,7 @@
         "name": "wp-graphql/wp-graphql-jwt-authentication",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-jwt-authentication/tarball/v0.6.0"
+          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-jwt-authentication/tarball/v0.7.0"
         }
       }
     },
@@ -508,7 +508,7 @@
         "name": "wp-graphql/wp-graphql-woocommerce",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-woocommerce/tarball/v0.12.1"
+          "url": "https://api.github.com/repos/wp-graphql/wp-graphql-woocommerce/tarball/v0.12.3"
         }
       }
     },
@@ -532,7 +532,7 @@
         "name": "pristas-peter/wp-graphql-gutenberg",
         "dist": {
           "type": "tar",
-          "url": "https://api.github.com/repos/pristas-peter/wp-graphql-gutenberg/tarball/v0.3.11"
+          "url": "https://api.github.com/repos/pristas-peter/wp-graphql-gutenberg/tarball/v0.4.1"
         }
       }
     },

--- a/plugins.yml
+++ b/plugins.yml
@@ -67,7 +67,6 @@ github:
   - name: wp-graphql-gutenberg
     type: release_src
     repo: pristas-peter/wp-graphql-gutenberg
-    release_pin: "v0.3.11"
   - name: wp-graphql-gutenberg-acf
     type: release_src
     repo: pristas-peter/wp-graphql-gutenberg-acf


### PR DESCRIPTION
- Advanced Custom Fields 6.0.7 to  6.1.3
- All-in-One WP Migration 7.71 to 7.73
- Classic Editor 1.6.2  to 1.6.3
- Admin Columns 4.5.5 to 4.6.1
- Custom Post Type UI 1.13.4 to 1.13.5
- Code Snippets 3.2.2  to 3.3.0
- Enable Media Replace 4.0.3 to 4.1.0
- Export Media Library  4.0.0 to  4.0.2
- Faust 0.8.1 to 0.8.4
- Redirection 5.3.9 to 5.3.10
- Safe SVG  2.0.3 to 2.1.1
- TablePress 2.0.4 to 2.1
- The Events Calendar 6.0.10 to 6.0.11
- User Role Editor 4.63.2 to 4.63.3
- WPGraphQL 1.6.11 to 1.14.0
- WP Search with Algolia 2.4.0 to 2.5.0 
- Polylang 3.3.1 to 3.3.2
- Two Factor Authentication 1.14.11 to 1.14.14